### PR TITLE
Add support for Python 3

### DIFF
--- a/shortuuidfield/__init__.py
+++ b/shortuuidfield/__init__.py
@@ -1,7 +1,9 @@
+from __future__  import absolute_import
+
 try:
     VERSION = __import__('pkg_resources') \
         .get_distribution('django-shortuuidfield').version
 except Exception:
     VERSION = 'unknown'
 
-from fields import ShortUUIDField
+from .fields import ShortUUIDField


### PR DESCRIPTION
First of all, thanks for a great Django app @nebstrebor. I've used in several project so far and am really happy with it.

Now to the PR: I've started playing around with Python 3 and Django. In my little project I'd like to use your shortuuid field but importing it fails due to some incompatibilities with Python 3:
1. The `try...except` uses the old-style exception assignment that is not support in Python 3 anymore. Since you are not using the `e` variable anyway, I have simply removed it.
2. You are using an implicit relative import in `shortuuidfield.__init__.py` which doesn't work in Python 3. Only explicit relative imports are supported. I have updated the import statement and added another import to enforce the explicit behaviour in Python 2.x. The [Python wiki](https://wiki.python.org/moin/PortingPythonToPy3k#relative-imports) has some more details on the relative imports if you are curious.

Looking forward to your feedback.
