### PR TITLE
Fixed unicode handling for Python 3.

### DIFF
--- a/shortuuidfield/fields.py
+++ b/shortuuidfield/fields.py
@@ -1,4 +1,5 @@
 import shortuuid
+import sys
 from django.db.models import CharField
 
 
@@ -30,7 +31,10 @@ class ShortUUIDField(CharField):
         value = super(ShortUUIDField, self).pre_save(model_instance, add)
         if self.auto and not value:
             # Assign a new value for this attribute if required.
-            value = unicode(shortuuid.uuid())
+            if sys.version_info < (3, 0):
+                value = unicode(shortuuid.uuid())
+            else:
+                value = str(shortuuid.uuid())
             setattr(model_instance, self.attname, value)
         return value
 


### PR DESCRIPTION
Hi,

Python 3 does not have unicode() function.
So changed using str() instead of unicode() when Python3.

Best regards,

Signed-off-by: Kouhei Maeda <mkouhei@palmtb.net>